### PR TITLE
Add remote goals source switching

### DIFF
--- a/Src/components/TopBar.tsx
+++ b/Src/components/TopBar.tsx
@@ -5,8 +5,6 @@ type Props = {
     settings: RoomSettings
     onChange: (patch: Partial<RoomSettings>) => void
     onRegenerate: () => void
-    onLoadGoalsFile?: (file: File) => void
-    onLoadGoalsUrl?: (url: string) => void
     showLoaders?: boolean
     gameTimer?: GameTimerState
     isHost?: boolean
@@ -14,6 +12,8 @@ type Props = {
     onPause?: () => void
     onNextStage?: () => void
     onResetRun?: () => void
+    goalsSource: 'local' | 'remote'
+    setGoalsSource: React.Dispatch<React.SetStateAction<'local' | 'remote'>>
 }
 
 
@@ -21,8 +21,6 @@ export default function TopBar({
     settings,
     onChange,
     onRegenerate,
-    onLoadGoalsFile,
-    onLoadGoalsUrl,
     showLoaders = true,
     gameTimer,
     isHost,
@@ -30,10 +28,9 @@ export default function TopBar({
     onPause,
     onNextStage,
     onResetRun,
+    goalsSource,
+    setGoalsSource,
 }: Props) {
-
-    const [url, setUrl] = React.useState('')
-
     function formatTime(sec: number) {
         const m = Math.floor(sec / 60)
         const s = sec % 60
@@ -172,31 +169,20 @@ export default function TopBar({
                 </div>
             )}
 
-            {/* {showLoaders && (
+            {showLoaders && (
                 <div className="flex items-center gap-2">
-                    <input
-                        type="file"
-                        accept=".json,.csv"
-                        onChange={e => {
-                            const f = e.target.files?.[0]
-                            if (f) onLoadGoalsFile?.(f)
-                        }}
-                    />
-                    <input
-                        value={url}
-                        onChange={e => setUrl(e.target.value)}
-                        placeholder="https://.../goals.json|csv"
-                        className="px-2 py-1 rounded bg-neutral-800 border border-neutral-700 text-sm w-72"
-                    />
-                    <button
-                        onClick={() => onLoadGoalsUrl?.(url)}
+                    <label className="text-sm opacity-80">Goals</label>
+                    <select
+                        value={goalsSource}
+                        onChange={e => setGoalsSource(e.target.value as 'local' | 'remote')}
                         className="px-2 py-1 rounded bg-neutral-800 border border-neutral-700 text-sm"
                     >
-                        Load URL
-                    </button>
+                        <option value="local">Local file</option>
+                        <option value="remote">Google Sheet</option>
+                    </select>
                     <span className="text-xs opacity-70">{settings.goalsSource ?? 'no pool loaded'}</span>
                 </div>
-            )} */}
+            )}
 
         </div>
     )


### PR DESCRIPTION
## Summary
- Introduce remote goals CSV constant and track whether goals come from local JSON or a remote sheet.
- Load goals conditionally from local file or Google Sheet CSV and regenerate the board accordingly.
- Add a source selector in the top bar UI for switching between local and remote goals.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "/src/main.tsx" from "/workspace/TinyBingo/index.html")*


------
https://chatgpt.com/codex/tasks/task_e_68ac61afbfc88328ae4a6c93191ff5b9